### PR TITLE
Added additional config options: "Minimum Meteor Size To Spawn Nether Portal", "Meteor Impact Explosion Multiplier" and "Meteor Impact Spread".

### DIFF
--- a/src/minecraft/net/meteor/common/MeteorsMod.java
+++ b/src/minecraft/net/meteor/common/MeteorsMod.java
@@ -163,6 +163,9 @@ implements ICraftingHandler, IFuelHandler, IWorldGenerator
 	public boolean unknownEnabled;
 	private int chunkChecks;
 	private int oreGenSize;
+	public int MinMeteorSizeForPortal;
+	public double ImpactExplosionMultiplier;
+	public int ImpactSpread;
 
 	private void setVars()
 	{
@@ -339,6 +342,21 @@ implements ICraftingHandler, IFuelHandler, IWorldGenerator
 			this.MinMeteorSize = this.MaxMeteorSize;
 		else if (this.MaxMeteorSize < this.MinMeteorSize) {
 			this.MaxMeteorSize = this.MinMeteorSize;
+		}
+		this.MinMeteorSizeForPortal = config.get("general", "Minimum Meteor Size To Spawn Nether Portal", 2).getInt();
+		if (this.MinMeteorSizeForPortal < this.MinMeteorSize)
+			this.MinMeteorSizeForPortal = this.MinMeteorSize;
+		this.ImpactExplosionMultiplier = config.get("general", "Meteor Impact Explosion Multiplier", 5.0).getDouble(5.0);
+		if (this.ImpactExplosionMultiplier > 20.0)
+			this.ImpactExplosionMultiplier = 20.0;
+		else if (this.ImpactExplosionMultiplier < 0.0) {
+			this.ImpactExplosionMultiplier = 0.0;
+		}
+		this.ImpactSpread = config.get("general", "Meteor Impact Spread", 4).getInt();
+		if (this.ImpactSpread > 8)
+			this.ImpactSpread = 8;
+		else if (this.ImpactSpread < 0) {
+			this.ImpactSpread = 0;
 		}
 		config.save();
 	}

--- a/src/minecraft/net/meteor/common/crash/CrashKreknorite.java
+++ b/src/minecraft/net/meteor/common/crash/CrashKreknorite.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import net.meteor.common.ClientHandler;
 import net.meteor.common.EnumMeteor;
 import net.meteor.common.LangLocalization;
+import net.meteor.common.MeteorsMod;
 import net.meteor.common.SBAPI;
 import net.minecraft.block.Block;
 import net.minecraft.entity.monster.EntityBlaze;
@@ -24,7 +25,7 @@ public class CrashKreknorite extends CrashMeteorite
 	}
 
 	public void afterCraterFormed(World world, Random random, int i, int j, int k) {
-		if (this.crashSize >= 2) {
+		if (this.crashSize >= MeteorsMod.instance.MinMeteorSizeForPortal) {
 			createPortal(world, i, j, k, random.nextBoolean());
 		}
 		int blazes = random.nextInt(3);
@@ -106,7 +107,7 @@ public class CrashKreknorite extends CrashMeteorite
 	}
 
 	public void afterCrashCompleted(World world, int i, int j, int k) {
-		if (this.crashSize >= 2 && !world.isRemote) {
+		if (this.crashSize >= MeteorsMod.instance.MinMeteorSizeForPortal && !world.isRemote) {
 			ClientHandler.sendPacketToAllInWorld(world, new Packet3Chat(ChatMessageComponent.createFromText(LangLocalization.get("Meteor.netherPortalCreation")).setColor(EnumChatFormatting.DARK_RED)));
 		}
 	}

--- a/src/minecraft/net/meteor/common/crash/CrashMeteorite.java
+++ b/src/minecraft/net/meteor/common/crash/CrashMeteorite.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Random;
 
 import net.meteor.common.EnumMeteor;
+import net.meteor.common.MeteorsMod;
 import net.meteor.common.entity.EntityAlienCreeper;
 import net.minecraft.block.Block;
 import net.minecraft.util.MathHelper;
@@ -31,9 +32,9 @@ public class CrashMeteorite extends WorldGenerator
 		int rareMeteor = this.meteorType.getRareMaterialID();
 
 		//Initial spreading
-		for (int y = j + 4 * this.crashSize; y >= j - 4 * this.crashSize; y--) {
-			for (int startX = i + 4 * this.crashSize; startX >= i - 4 * this.crashSize; startX--) {
-				for (int startZ = k + 4 * this.crashSize; startZ >= k - 4 * this.crashSize; startZ--) {
+		for (int y = j + MeteorsMod.instance.ImpactSpread * this.crashSize; y >= j - MeteorsMod.instance.ImpactSpread * this.crashSize; y--) {
+			for (int startX = i + MeteorsMod.instance.ImpactSpread * this.crashSize; startX >= i - MeteorsMod.instance.ImpactSpread * this.crashSize; startX--) {
+				for (int startZ = k + MeteorsMod.instance.ImpactSpread * this.crashSize; startZ >= k - MeteorsMod.instance.ImpactSpread * this.crashSize; startZ--) {
 					if ((!world.isAirBlock(startX, y, startZ)) && (meteorsAboveAndBelow(world, startX, y, startZ) == 0) && (random.nextInt(10) + 1 > 7) && (checkBlockIDs(world, startX, y, startZ))) {
 						int theBlock = random.nextInt(45) == 25 ? rareMeteor : meteor;
 						if (theBlock == Block.ice.blockID || theBlock == Block.lavaStill.blockID) {
@@ -48,9 +49,9 @@ public class CrashMeteorite extends WorldGenerator
 		}
 
 		//Bottom layer spreading for a higher concentration in center
-		for (int y = j - 4 * this.crashSize; y >= j - (4 * this.crashSize + 1); y--) {
-			for (int startX = i + 4 * this.crashSize; startX >= i - 4 * this.crashSize; startX--) {
-				for (int startZ = k + 4 * this.crashSize; startZ >= k - 4 * this.crashSize; startZ--) {
+		for (int y = j - MeteorsMod.instance.ImpactSpread * this.crashSize; y >= j - (MeteorsMod.instance.ImpactSpread * this.crashSize + 1); y--) {
+			for (int startX = i + MeteorsMod.instance.ImpactSpread * this.crashSize; startX >= i - MeteorsMod.instance.ImpactSpread * this.crashSize; startX--) {
+				for (int startZ = k + MeteorsMod.instance.ImpactSpread * this.crashSize; startZ >= k - MeteorsMod.instance.ImpactSpread * this.crashSize; startZ--) {
 					if ((!world.isAirBlock(startX, y, startZ)) && (meteorsAboveAndBelow(world, startX, y, startZ) == 0) && (checkBlockIDs(world, startX, y, startZ))) {
 						int theBlock = random.nextInt(45) == 25 ? rareMeteor : meteor;
 						if (theBlock == Block.ice.blockID || theBlock == Block.lavaStill.blockID) {

--- a/src/minecraft/net/meteor/common/entity/EntityMeteor.java
+++ b/src/minecraft/net/meteor/common/entity/EntityMeteor.java
@@ -138,7 +138,7 @@ implements IEntityAdditionalSpawnData
 	}
 
 	protected Explosion explode() {
-		float f = 5.0F * this.size;
+		float f = (float) (this.size * MeteorsMod.instance.ImpactExplosionMultiplier);
 		return worldObj.newExplosion(null, posX, posY, posZ, f, meteorType.getFieryExplosion(), true);
 	}
 


### PR DESCRIPTION
Added additional config options, with defaults that match the current mod behavior.

"Minimum Meteor Size To Spawn Nether Portal" (default 2)
Can disable portal creation by setting this higher than the "Maximum Meteor Size".

"Meteor Impact Explosion Multiplier" (0.0 - 20.0, default 5.0)
Allows for more or less powerful meteor crash explosions.

"Meteor Impact Spread" (0 - 8, default 4)
Control how much meteor ore is generated on impact.
